### PR TITLE
feat: correct language attribute for html document

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import Script from "next/script";
 import ThemeProvider from "@/components/Provider/Theme";
 import I18Provider from "@/components/Provider/I18n";
+import LanguageAttribute from "@/components/Provider/LanguageAttribute";
 import { Toaster } from "@/components/ui/sonner";
 
 import "./globals.css";
@@ -48,6 +49,7 @@ export default function RootLayout({
           <I18Provider>{children}</I18Provider>
         </ThemeProvider>
         <Toaster richColors toastOptions={{ duration: 3000 }} />
+        <LanguageAttribute />
       </body>
     </html>
   );

--- a/src/components/Provider/LanguageAttribute.tsx
+++ b/src/components/Provider/LanguageAttribute.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSettingStore } from "@/store/setting";
+
+export default function LanguageAttribute() {
+  const { language } = useSettingStore();
+
+  useEffect(() => {
+    if (language) {
+      document.documentElement.setAttribute("lang", language);
+    }
+  }, [language]);
+
+  return null;
+} 


### PR DESCRIPTION
Fixes Issue #38: Update lang Attribute in HTML Document

Changelog:
- Added LanguageAttribute component to manage the HTML lang attribute dynamically.
- Integrated LanguageAttribute component into the main layout.

<img width="1917" alt="Screenshot 2568-04-16 at 13 18 06" src="https://github.com/user-attachments/assets/4ae61645-49c0-42bb-8a98-a584cbb11913" />
<img width="1917" alt="Screenshot 2568-04-16 at 13 18 28" src="https://github.com/user-attachments/assets/68e60da9-4f02-404b-a832-007508b77557" />
