### PR TITLE
refactor: migrate storage from localStorage to IndexedDB

### DIFF
--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { persist, type StorageValue } from "zustand/middleware";
+import { researchStore } from "@/utils/storage";
+import { pick } from "radash";
 
 export interface SettingStore {
   provider: string;
@@ -175,6 +177,26 @@ export const useSettingStore = create(
       update: (values) => set(values),
       reset: () => set(defaultValues),
     }),
-    { name: "setting" }
+    {
+      name: "setting",
+      version: 1,
+      storage: {
+        getItem: async (key: string) => {
+          return await researchStore.getItem<
+            StorageValue<SettingStore & SettingActions>
+          >(key);
+        },
+        setItem: async (
+          key: string,
+          store: StorageValue<SettingStore & SettingActions>
+        ) => {
+          return await researchStore.setItem(key, {
+            state: pick(store.state, Object.keys(defaultValues) as (keyof SettingStore)[]),
+            version: store.version,
+          });
+        },
+        removeItem: async (key: string) => await researchStore.removeItem(key),
+      },
+    }
   )
 );

--- a/src/store/task.ts
+++ b/src/store/task.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { persist, type StorageValue } from "zustand/middleware";
 import { pick } from "radash";
+import { researchStore } from "@/utils/storage";
 
 export interface TaskStore {
   id: string;
@@ -117,6 +118,26 @@ export const useTaskStore = create(
       },
       restore: (taskStore) => set(() => ({ ...taskStore })),
     }),
-    { name: "research" }
+    {
+      name: "research",
+      version: 1,
+      storage: {
+        getItem: async (key: string) => {
+          return await researchStore.getItem<
+            StorageValue<TaskStore & TaskActions>
+          >(key);
+        },
+        setItem: async (
+          key: string,
+          store: StorageValue<TaskStore & TaskActions>
+        ) => {
+          return await researchStore.setItem(key, {
+            state: pick(store.state, Object.keys(defaultValues) as (keyof TaskStore)[]),
+            version: store.version,
+          });
+        },
+        removeItem: async (key: string) => await researchStore.removeItem(key),
+      },
+    }
   )
 );


### PR DESCRIPTION
- Replace default localStorage with IndexedDB via researchStore
- To avoid the following error, which occurs when processing extensive text and a large volume of images: `QuotaExceededError: Failed to execute 'setItem' on 'Storage': Setting the value of 'research' exceeded the quota`