### PR TITLE
docs: add CRW as Firecrawl-compatible alternative for web search

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ pnpm build:export
 
 ## 🔍 Using CRW as a Firecrawl Alternative
 
-[CRW](https://github.com/us/crw) is an open-source, Firecrawl-compatible web scraper that you can self-host or use via the cloud ([fastcrw.com](https://fastcrw.com)). Since CRW is a drop-in replacement for Firecrawl, you can use it as your search provider without any code changes — just set the `FIRECRAWL_API_BASE_URL` environment variable.
+[CRW](https://github.com/us/crw) is an open-source, Firecrawl-compatible web scraper that you can self-host or use via the cloud ([fastcrw.com](https://fastcrw.com)). Since CRW is a drop-in replacement for Firecrawl, you can use it as your search provider without any code changes — just set the `FIRECRAWL_API_BASE_URL` environment variable. This variable is used for server-side API calls and the proxy path; client-side (browser) calls are not affected by this setting.
 
 ### Self-hosted CRW
 
@@ -209,6 +209,8 @@ pnpm build:export
    ```bash
    FIRECRAWL_API_BASE_URL=http://localhost:3002
    ```
+
+   > **Docker users:** If Deep Research is running inside a Docker container, `localhost` refers to the container itself. Use `host.docker.internal` (Docker Desktop) or the docker-compose service name instead (e.g., `http://host.docker.internal:3002`).
 
 3. Select **Firecrawl** as your search provider in the Deep Research settings.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Deep Research uses a variety of powerful AI models to generate in-depth research
 - **Powered by AI:** Utilizes the advanced AI models for accurate and insightful analysis.
 - **Privacy-Focused:** Your data remains private and secure, as all data is stored locally on your browser.
 - **Support for Multi-LLM:** Supports a variety of mainstream large language models, including Gemini, OpenAI, Anthropic, Deepseek, Grok, Mistral, Azure OpenAI, any OpenAI Compatible LLMs, OpenRouter, Ollama, etc.
-- **Support Web Search:** Supports search engines such as Searxng, Tavily, Firecrawl, Exa, Bocha, Brave, etc., allowing LLMs that do not support search to use the web search function more conveniently.
+- **Support Web Search:** Supports search engines such as Searxng, Tavily, Firecrawl, [CRW](https://github.com/us/crw), Exa, Bocha, Brave, etc., allowing LLMs that do not support search to use the web search function more conveniently.
 - **Thinking & Task Models:** Employs sophisticated "Thinking" and "Task" models to balance depth and speed, ensuring high-quality results quickly. Support switching research models.
 - **Support Further Research:** You can refine or adjust the research content at any stage of the project and support re-research from that stage.
 - **Local Knowledge Base:** Supports uploading and processing text, Office, PDF and other resource files to generate local knowledge base.
@@ -191,6 +191,37 @@ You can also build a static page version directly, and then upload all files in 
 ```bash
 pnpm build:export
 ```
+
+## 🔍 Using CRW as a Firecrawl Alternative
+
+[CRW](https://github.com/us/crw) is an open-source, Firecrawl-compatible web scraper that you can self-host or use via the cloud ([fastcrw.com](https://fastcrw.com)). Since CRW is a drop-in replacement for Firecrawl, you can use it as your search provider without any code changes — just set the `FIRECRAWL_API_BASE_URL` environment variable.
+
+### Self-hosted CRW
+
+1. Start the CRW server (default port 3002):
+
+   ```bash
+   docker run -d --name crw -p 3002:3002 ghcr.io/us/crw
+   ```
+
+2. Set the environment variable to point to your CRW instance:
+
+   ```bash
+   FIRECRAWL_API_BASE_URL=http://localhost:3002
+   ```
+
+3. Select **Firecrawl** as your search provider in the Deep Research settings.
+
+### Cloud CRW
+
+To use the hosted version at [fastcrw.com](https://fastcrw.com):
+
+```bash
+FIRECRAWL_API_BASE_URL=https://fastcrw.com
+FIRECRAWL_API_KEY=your-crw-api-key
+```
+
+> **Note:** When using self-hosted CRW, the `FIRECRAWL_API_KEY` may not be required depending on your CRW configuration.
 
 ## ⚙️ Configuration
 

--- a/env.tpl
+++ b/env.tpl
@@ -76,6 +76,9 @@ TAVILY_API_BASE_URL=
 # (Optional) Server-side Firecrawl API Key (Required for server API calls)
 FIRECRAWL_API_KEY=
 # (Optional) Server-side Firecrawl API Proxy URL. Default, `https://api.firecrawl.dev`
+# You can also use CRW (https://github.com/us/crw), an open-source Firecrawl-compatible alternative.
+# Self-hosted: FIRECRAWL_API_BASE_URL=http://localhost:3002
+# Cloud: FIRECRAWL_API_BASE_URL=https://fastcrw.com
 FIRECRAWL_API_BASE_URL=
 
 # (Optional) Server-side Exa API Key (Required for server API calls)

--- a/env.tpl
+++ b/env.tpl
@@ -78,6 +78,7 @@ FIRECRAWL_API_KEY=
 # (Optional) Server-side Firecrawl API Proxy URL. Default, `https://api.firecrawl.dev`
 # You can also use CRW (https://github.com/us/crw), an open-source Firecrawl-compatible alternative.
 # Self-hosted: FIRECRAWL_API_BASE_URL=http://localhost:3002
+# Note: In Docker, use host.docker.internal or docker-compose service name instead of localhost
 # Cloud: FIRECRAWL_API_BASE_URL=https://fastcrw.com
 FIRECRAWL_API_BASE_URL=
 


### PR DESCRIPTION
## Summary
- Add documentation for [CRW](https://github.com/us/crw), an open-source Firecrawl-compatible web scraper, as a drop-in alternative search provider
- Include setup instructions for both self-hosted (`localhost:3002`) and cloud ([fastcrw.com](https://fastcrw.com)) usage via `FIRECRAWL_API_BASE_URL`
- Add CRW comments to `env.tpl` for discoverability

## Details
[CRW](https://github.com/us/crw) is fully compatible with the Firecrawl API, so users can switch to it by simply setting:

```bash
FIRECRAWL_API_BASE_URL=http://localhost:3002
```

No code changes are needed — it works with the existing Firecrawl search provider selection.

## Changes
- `README.md`: Added CRW to the web search feature list and a new section with self-hosted/cloud setup instructions
- `env.tpl`: Added comments about CRW as an alternative for `FIRECRAWL_API_BASE_URL`