### PR TITLE
fix: allow previous time chunk in verifySignature

### DIFF
--- a/src/utils/signature.ts
+++ b/src/utils/signature.ts
@@ -10,6 +10,8 @@ export function verifySignature(
   key: string,
   timestamp: number
 ): boolean {
+  // Check the current 100s window and the previous 100s window (offset by 10^5 ms)
   const generatedSignature = generateSignature(key, timestamp);
-  return signature === generatedSignature;
+  const generatedPreviousSignature = generateSignature(key, timestamp - 100000);
+  return signature === generatedSignature || signature === generatedPreviousSignature;
 }


### PR DESCRIPTION
verifySignature is grouping time into chunks of 100,000 milliseconds. If the frontend generated the signature at 1776000099999 and the backend checked it at 1776000100001 (just 2 milliseconds later), the substring changes from 17760000 to 17760001. The hash will be completely different. This commit fixes this by also checking against the previous time window.

Refs: #158