### PR TITLE
fix: handle empty request body for searxng

### DIFF
--- a/src/app/api/search/searxng/[...slug]/route.ts
+++ b/src/app/api/search/searxng/[...slug]/route.ts
@@ -18,7 +18,8 @@ const API_PROXY_BASE_URL = process.env.SEARXNG_API_BASE_URL || SEARXNG_BASE_URL;
 export async function POST(req: NextRequest) {
   let body;
   if (req.method.toUpperCase() !== "GET") {
-    body = await req.json();
+    const text = await req.text();
+    body = text ? JSON.parse(text) : null;
   }
   const searchParams = req.nextUrl.searchParams;
   const path = searchParams.getAll("slug");


### PR DESCRIPTION
The frontend sends a request to POST /api/search/searxng/search with no request body, but the code tries to extract it as json, which effectly parses empty string to json, which fails. This commit sets the body to null if the request body is absent.

Refs: #91