### PR TITLE
feat: add fastCRW (Firecrawl-compatible) search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Deep Research uses a variety of powerful AI models to generate in-depth research
 - **Powered by AI:** Utilizes the advanced AI models for accurate and insightful analysis.
 - **Privacy-Focused:** Your data remains private and secure, as all data is stored locally on your browser.
 - **Support for Multi-LLM:** Supports a variety of mainstream large language models, including Gemini, OpenAI, Anthropic, Deepseek, Grok, Mistral, Azure OpenAI, any OpenAI Compatible LLMs, OpenRouter, Ollama, etc.
-- **Support Web Search:** Supports search engines such as Searxng, Tavily, Firecrawl, Exa, Bocha, Brave, etc., allowing LLMs that do not support search to use the web search function more conveniently.
+- **Support Web Search:** Supports search engines such as Searxng, Tavily, Firecrawl, fastCRW, Exa, Bocha, Brave, etc., allowing LLMs that do not support search to use the web search function more conveniently.
 - **Thinking & Task Models:** Employs sophisticated "Thinking" and "Task" models to balance depth and speed, ensuring high-quality results quickly. Support switching research models.
 - **Support Further Research:** You can refine or adjust the research content at any stage of the project and support re-research from that stage.
 - **Local Knowledge Base:** Supports uploading and processing text, Office, PDF and other resource files to generate local knowledge base.
@@ -236,7 +236,7 @@ interface SSEConfig {
   thinkingModel: string;
   // Task model id
   taskModel: string;
-  // Search provider, Possible values ​​include: model, tavily, firecrawl, exa, bocha, searxng
+  // Search provider, Possible values ​​include: model, tavily, firecrawl, crw, exa, bocha, searxng
   searchProvider: string;
   // Response Language, also affects the search language. (optional)
   language?: string;
@@ -327,7 +327,7 @@ If your server sets `ACCESS_PASSWORD`, the MCP service will be protected and you
 # Possible values ​​include: google, openai, anthropic, deepseek, xai, mistral, azure, openrouter, openaicompatible, pollinations, ollama
 MCP_AI_PROVIDER=google
 # MCP Server search provider. Default, `model`
-# Possible values ​​include: model, tavily, firecrawl, exa, bocha, searxng
+# Possible values ​​include: model, tavily, firecrawl, crw, exa, bocha, searxng
 MCP_SEARCH_PROVIDER=tavily
 # MCP Server thinking model id, the core model used in deep research.
 MCP_THINKING_MODEL=gemini-2.0-flash-thinking-exp

--- a/docs/deep-research-api-doc.md
+++ b/docs/deep-research-api-doc.md
@@ -42,7 +42,7 @@ interface Config {
   thinkingModel: string;
   // Task model id
   taskModel: string;
-  // Search provider, Possible values ​​include: model, tavily, firecrawl, exa, bocha, searxng
+  // Search provider, Possible values ​​include: model, tavily, firecrawl, crw, exa, bocha, searxng
   searchProvider: string;
   // Response Language, also affects the search language. (optional)
   language?: string;

--- a/env.tpl
+++ b/env.tpl
@@ -78,6 +78,11 @@ FIRECRAWL_API_KEY=
 # (Optional) Server-side Firecrawl API Proxy URL. Default, `https://api.firecrawl.dev`
 FIRECRAWL_API_BASE_URL=
 
+# (Optional) Server-side fastCRW API Key (Required for server API calls)
+CRW_API_KEY=
+# (Optional) Server-side fastCRW API Proxy URL. Default, `https://fastcrw.com/api`
+CRW_API_BASE_URL=
+
 # (Optional) Server-side Exa API Key (Required for server API calls)
 EXA_API_KEY=
 # (Optional) Server-side Exa API Proxy URL. Default, `https://api.exa.ai`
@@ -100,7 +105,7 @@ SEARXNG_API_BASE_URL=
 # Possible values ​​include: google, openai, anthropic, deepseek, xai, mistral, azure, openrouter, openaicompatible, pollinations, ollama
 MCP_AI_PROVIDER=
 # (Optional) MCP Server search provider. Default, `model`
-# Possible values ​​include: model, tavily, firecrawl, exa, bocha, searxng
+# Possible values ​​include: model, tavily, firecrawl, crw, exa, bocha, searxng
 MCP_SEARCH_PROVIDER=
 # (Optional) MCP Server thinking model id, the core model used in deep research.
 MCP_THINKING_MODEL=
@@ -111,7 +116,7 @@ MCP_TASK_MODEL=
 # Possible values ​​include: google, openai, anthropic, deepseek, xai, mistral, azure, openrouter, openaicompatible, pollinations, ollama
 NEXT_PUBLIC_DISABLED_AI_PROVIDER=
 # (Optional) Disable server-side search provider usage permissions
-# Possible values ​​include: model, tavily, firecrawl, exa, bocha, searxng
+# Possible values ​​include: model, tavily, firecrawl, crw, exa, bocha, searxng
 NEXT_PUBLIC_DISABLED_SEARCH_PROVIDER=
 # (Optional) Customize the model list, add or delete models
 NEXT_PUBLIC_MODEL_LIST=

--- a/next.config.ts
+++ b/next.config.ts
@@ -34,6 +34,8 @@ const TAVILY_API_BASE_URL =
   process.env.TAVILY_API_BASE_URL || "https://api.tavily.com";
 const FIRECRAWL_API_BASE_URL =
   process.env.FIRECRAWL_API_BASE_URL || "https://api.firecrawl.dev";
+const CRW_API_BASE_URL =
+  process.env.CRW_API_BASE_URL || "https://fastcrw.com/api";
 const EXA_API_BASE_URL = process.env.EXA_API_BASE_URL || "https://api.exa.ai";
 const BOCHA_API_BASE_URL =
   process.env.BOCHA_API_BASE_URL || "https://api.bochaai.com";
@@ -132,6 +134,10 @@ export default async function Config(phase: string) {
         {
           source: "/api/search/firecrawl/:path*",
           destination: `${FIRECRAWL_API_BASE_URL}/:path*`,
+        },
+        {
+          source: "/api/search/crw/:path*",
+          destination: `${CRW_API_BASE_URL}/:path*`,
         },
         {
           source: "/api/search/exa/:path*",

--- a/src/app/api/search/crw/[...slug]/route.ts
+++ b/src/app/api/search/crw/[...slug]/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { CRW_BASE_URL } from "@/constants/urls";
+
+export const runtime = "edge";
+export const preferredRegion = [
+  "cle1",
+  "iad1",
+  "pdx1",
+  "sfo1",
+  "sin1",
+  "syd1",
+  "hnd1",
+  "kix1",
+];
+
+const API_PROXY_BASE_URL = process.env.CRW_API_BASE_URL || CRW_BASE_URL;
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const searchParams = req.nextUrl.searchParams;
+  const path = searchParams.getAll("slug");
+  searchParams.delete("slug");
+  const params = searchParams.toString();
+
+  try {
+    let url = `${API_PROXY_BASE_URL}/${decodeURIComponent(path.join("/"))}`;
+    if (params) url += `?${params}`;
+    const payload: RequestInit = {
+      method: req.method,
+      headers: {
+        "Content-Type": req.headers.get("Content-Type") || "application/json",
+        Authorization: req.headers.get("Authorization") || "",
+      },
+      body: JSON.stringify(body),
+    };
+    const response = await fetch(url, payload);
+    return new NextResponse(response.body, response);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(error);
+      return NextResponse.json(
+        { code: 500, message: error.message },
+        { status: 500 }
+      );
+    }
+  }
+}

--- a/src/app/api/utils.ts
+++ b/src/app/api/utils.ts
@@ -28,6 +28,8 @@ const TAVILY_API_BASE_URL =
   process.env.TAVILY_API_BASE_URL || "https://api.tavily.com";
 const FIRECRAWL_API_BASE_URL =
   process.env.FIRECRAWL_API_BASE_URL || "https://api.firecrawl.dev";
+const CRW_API_BASE_URL =
+  process.env.CRW_API_BASE_URL || "https://fastcrw.com/api";
 const EXA_API_BASE_URL = process.env.EXA_API_BASE_URL || "https://api.exa.ai";
 const BOCHA_API_BASE_URL =
   process.env.BOCHA_API_BASE_URL || "https://api.bochaai.com";
@@ -48,6 +50,7 @@ const GOOGLE_VERTEX_API_BASE_URL = `https://${process.env.GOOGLE_VERTEX_LOCATION
 // Search provider API key
 const TAVILY_API_KEY = process.env.TAVILY_API_KEY || "";
 const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY || "";
+const CRW_API_KEY = process.env.CRW_API_KEY || "";
 const EXA_API_KEY = process.env.EXA_API_KEY || "";
 const BOCHA_API_KEY = process.env.BOCHA_API_KEY || "";
 
@@ -117,6 +120,8 @@ export function getSearchProviderBaseURL(provider: string) {
       return TAVILY_API_BASE_URL;
     case "firecrawl":
       return FIRECRAWL_API_BASE_URL;
+    case "crw":
+      return CRW_API_BASE_URL;
     case "exa":
       return EXA_API_BASE_URL;
     case "bocha":
@@ -136,6 +141,8 @@ export function getSearchProviderApiKey(provider: string) {
       return TAVILY_API_KEY;
     case "firecrawl":
       return FIRECRAWL_API_KEY;
+    case "crw":
+      return CRW_API_KEY;
     case "exa":
       return EXA_API_KEY;
     case "bocha":

--- a/src/components/Setting.tsx
+++ b/src/components/Setting.tsx
@@ -64,6 +64,7 @@ import {
   OLLAMA_BASE_URL,
   TAVILY_BASE_URL,
   FIRECRAWL_BASE_URL,
+  CRW_BASE_URL,
   EXA_BASE_URL,
   BOCHA_BASE_URL,
   BRAVE_BASE_URL,
@@ -158,6 +159,8 @@ const formSchema = z.object({
   tavilyScope: z.string().optional(),
   firecrawlApiKey: z.string().optional(),
   firecrawlApiProxy: z.string().optional(),
+  crwApiKey: z.string().optional(),
+  crwApiProxy: z.string().optional(),
   exaApiKey: z.string().optional(),
   exaApiProxy: z.string().optional(),
   exaScope: z.string().optional(),
@@ -3055,6 +3058,9 @@ function Setting({ open, onClose }: SettingProps) {
                                 Firecrawl
                               </SelectItem>
                             ) : null}
+                            {!isDisabledSearchProvider("crw") ? (
+                              <SelectItem value="crw">fastCRW</SelectItem>
+                            ) : null}
                             {!isDisabledSearchProvider("exa") &&
                             mode === "proxy" ? (
                               <SelectItem value="exa">Exa</SelectItem>
@@ -3191,6 +3197,52 @@ function Setting({ open, onClose }: SettingProps) {
                           <FormControl className="form-field">
                             <Input
                               placeholder={FIRECRAWL_BASE_URL}
+                              disabled={form.getValues("enableSearch") === "0"}
+                              {...field}
+                            />
+                          </FormControl>
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+                  <div
+                    className={cn("space-y-4", {
+                      hidden: searchProvider !== "crw",
+                    })}
+                  >
+                    <FormField
+                      control={form.control}
+                      name="crwApiKey"
+                      render={({ field }) => (
+                        <FormItem className="from-item">
+                          <FormLabel className="from-label">
+                            {t("setting.apiKeyLabel")}
+                            <span className="ml-1 text-red-500 max-sm:hidden">
+                              *
+                            </span>
+                          </FormLabel>
+                          <FormControl className="form-field">
+                            <Password
+                              type="text"
+                              placeholder={t("setting.searchApiKeyPlaceholder")}
+                              disabled={form.getValues("enableSearch") === "0"}
+                              {...field}
+                            />
+                          </FormControl>
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="crwApiProxy"
+                      render={({ field }) => (
+                        <FormItem className="from-item">
+                          <FormLabel className="from-label">
+                            {t("setting.apiUrlLabel")}
+                          </FormLabel>
+                          <FormControl className="form-field">
+                            <Input
+                              placeholder={CRW_BASE_URL}
                               disabled={form.getValues("enableSearch") === "0"}
                               {...field}
                             />

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -11,6 +11,7 @@ export const OLLAMA_BASE_URL = "http://localhost:11434";
 // Search engine API Base URL
 export const TAVILY_BASE_URL = "https://api.tavily.com";
 export const FIRECRAWL_BASE_URL = "https://api.firecrawl.dev";
+export const CRW_BASE_URL = "https://fastcrw.com/api";
 export const EXA_BASE_URL = "https://api.exa.ai";
 export const BOCHA_BASE_URL = "https://api.bochaai.com";
 export const BRAVE_BASE_URL = "https://api.search.brave.com/res";

--- a/src/hooks/useWebSearch.ts
+++ b/src/hooks/useWebSearch.ts
@@ -106,6 +106,15 @@ function useWebSearch() {
           options.baseURL = location.origin + "/api/search/firecrawl";
         }
         break;
+      case "crw":
+        const { crwApiKey, crwApiProxy } = useSettingStore.getState();
+        if (mode === "local") {
+          options.baseURL = crwApiProxy;
+          options.apiKey = multiApiKeyPolling(crwApiKey);
+        } else {
+          options.baseURL = location.origin + "/api/search/crw";
+        }
+        break;
       case "exa":
         const { exaApiKey, exaApiProxy, exaScope } = useSettingStore.getState();
         if (mode === "local") {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,6 +23,7 @@ const OPENAI_COMPATIBLE_API_KEY = process.env.OPENAI_COMPATIBLE_API_KEY || "";
 // Search provider API key
 const TAVILY_API_KEY = process.env.TAVILY_API_KEY || "";
 const FIRECRAWL_API_KEY = process.env.FIRECRAWL_API_KEY || "";
+const CRW_API_KEY = process.env.CRW_API_KEY || "";
 const EXA_API_KEY = process.env.EXA_API_KEY || "";
 const BOCHA_API_KEY = process.env.BOCHA_API_KEY || "";
 // Disabled Provider
@@ -606,6 +607,45 @@ export async function middleware(request: NextRequest) {
       );
     } else {
       const apiKey = multiApiKeyPolling(FIRECRAWL_API_KEY);
+      if (apiKey) {
+        const requestHeaders = new Headers();
+        requestHeaders.set(
+          "Content-Type",
+          request.headers.get("Content-Type") || "application/json",
+        );
+        requestHeaders.set("Authorization", `Bearer ${apiKey}`);
+        return NextResponse.next({
+          request: {
+            headers: requestHeaders,
+          },
+        });
+      } else {
+        return NextResponse.json(
+          {
+            error: ERRORS.NO_API_KEY,
+          },
+          { status: 500 },
+        );
+      }
+    }
+  }
+  if (request.nextUrl.pathname.startsWith("/api/search/crw")) {
+    const authorization = request.headers.get("authorization") || "";
+    if (
+      request.method.toUpperCase() !== "POST" ||
+      !verifySignature(
+        authorization.substring(7),
+        accessPassword,
+        Date.now(),
+      ) ||
+      disabledSearchProviders.includes("crw")
+    ) {
+      return NextResponse.json(
+        { error: ERRORS.NO_PERMISSIONS },
+        { status: 403 },
+      );
+    } else {
+      const apiKey = multiApiKeyPolling(CRW_API_KEY);
       if (apiKey) {
         const requestHeaders = new Headers();
         requestHeaders.set(

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -62,6 +62,8 @@ export interface SettingStore {
   tavilyScope: string;
   firecrawlApiKey: string;
   firecrawlApiProxy: string;
+  crwApiKey: string;
+  crwApiProxy: string;
   exaApiKey: string;
   exaApiProxy: string;
   exaScope: string;
@@ -157,6 +159,8 @@ export const defaultValues: SettingStore = {
   tavilyScope: "general",
   firecrawlApiKey: "",
   firecrawlApiProxy: "",
+  crwApiKey: "",
+  crwApiProxy: "",
   exaApiKey: "",
   exaApiProxy: "",
   exaScope: "research paper",

--- a/src/utils/deep-research/search.ts
+++ b/src/utils/deep-research/search.ts
@@ -1,6 +1,7 @@
 import {
   TAVILY_BASE_URL,
   FIRECRAWL_BASE_URL,
+  CRW_BASE_URL,
   EXA_BASE_URL,
   BOCHA_BASE_URL,
   BRAVE_BASE_URL,
@@ -225,6 +226,39 @@ export async function createSearchProvider({
   } else if (provider === "firecrawl") {
     const response = await fetch(
       `${completePath(baseURL || FIRECRAWL_BASE_URL, "/v1")}/search`,
+      {
+        method: "POST",
+        headers,
+        credentials: "omit",
+        body: JSON.stringify({
+          query,
+          limit: maxResult,
+          tbs: "qdr:w",
+          origin: "api",
+          scrapeOptions: {
+            formats: ["markdown"],
+          },
+          timeout: 60000,
+        }),
+      },
+    );
+    const { data = [] } = await response.json();
+    return {
+      sources: (data as FirecrawlDocument[])
+        .filter((item) => item.description && item.url)
+        .map((result) => ({
+          content: result.markdown || result.description,
+          url: result.url,
+          title: result.title,
+        })) as Source[],
+      images: [],
+    };
+  } else if (provider === "crw") {
+    // fastCRW is a Firecrawl-API-compatible web scraper (single binary,
+    // self-host or cloud), so it reuses the Firecrawl request/response shape
+    // with a different base URL.
+    const response = await fetch(
+      `${completePath(baseURL || CRW_BASE_URL, "/v1")}/search`,
       {
         method: "POST",
         headers,


### PR DESCRIPTION
## What

Adds **fastCRW** as a web-search provider, alongside the existing providers (Firecrawl, Exa, Bocha, Brave, SearXNG, …). Selectable from the search-provider setting like the others.

## Why

[fastCRW](https://fastcrw.com) is a **fully open, locally-runnable** web-scraping engine that outperforms Firecrawl on Firecrawl's own benchmark dataset and ships as a single ~8 MB Rust binary (~6 MB RAM at idle).

### What makes it better

- **Higher recall, lower latency — on Firecrawl's own benchmark data.** fastCRW scores **63.74% truth-recall vs 56.04%** for Firecrawl, with a median response time (p50) of **~1.9 s vs ~2.3 s**. Fewer missed pages, faster results.

- **The complete stealth stack ships in the open core (AGPL), with no cloud dependency.** Firecrawl's anti-bot / JS-challenge engine (`fire-engine`) is a cloud-only component — the OSS self-host falls back to plain fetch or Playwright and cannot bypass Cloudflare or most JS-heavy pages. fastCRW ships Cloudflare-challenge handling, UA rotation, SPA rendering, and BYO-proxy with rotation in the open-source binary, no asterisks. Self-host fastCRW and you get the real thing.

- **Search is not an alternative to SearXNG — it is built on top of it.** SearXNG is the metasearch aggregator underneath; fastCRW adds a quality layer on top: query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content rather than SearXNG's content-blind ordering), a calibrated direct-answer mode, and category routing (research queries fan out to arxiv / semantic scholar / Google Scholar, code queries to GitHub). You get SearXNG's breadth plus a measurable accuracy layer, all open-source (AGPL) and self-hostable with configurable engines.

- **Net result for `deep-research` users:** self-hosting fastCRW gives you a genuinely complete, cloud-free research stack. That combination isn't realistically achievable with Firecrawl's OSS build today.

### Why the diff is tiny

fastCRW is Firecrawl-API-compatible, so the adapter reuses the existing Firecrawl request/response types with a different base URL. No new abstractions needed.

## Changes (additive only — mirrors the existing Firecrawl provider's footprint exactly)

- `src/utils/deep-research/search.ts`: a `crw` branch reusing the Firecrawl request/response types.
- `src/app/api/search/crw/[...slug]/route.ts`: proxy route (mirrors the Firecrawl proxy route).
- `src/middleware.ts`, `src/constants/urls.ts`, `src/hooks/useWebSearch.ts`, `src/store/setting.ts`, `src/components/Setting.tsx`: registered the provider everywhere Firecrawl appears (config, UI entry, routing).
- `env.tpl`, `next.config.ts`, README + API doc note.

## Config

```bash
CRW_BASE_URL=https://fastcrw.com/api   # or your self-hosted URL
CRW_API_KEY=...                        # https://fastcrw.com/dashboard (free tier)
```

Happy to adjust anything to match your conventions — I maintain the integration and can provide free credits to evaluate.
