### PR TITLE
feat: add Requesty as an OpenAI-compatible provider

### DIFF
--- a/env.tpl
+++ b/env.tpl
@@ -25,6 +25,11 @@ OPENROUTER_API_KEY=
 # (Optional) Server-side OpenRouter API Proxy URL. Default, `https://openrouter.ai/api`
 OPENROUTER_API_BASE_URL=
 
+# (Optional) Server-side Requesty API Key (Required for server API calls)
+REQUESTY_API_KEY=
+# (Optional) Server-side Requesty API Proxy URL. Default, `https://router.requesty.ai`
+REQUESTY_API_BASE_URL=
+
 # (Optional) Server-side OpenAI API Key (Required for server API calls)
 OPENAI_API_KEY=
 # (Optional) Server-side OpenAI API Proxy URL. Default, `https://api.openai.com`

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,8 @@ const GOOGLE_GENERATIVE_AI_API_BASE_URL =
   "https://generativelanguage.googleapis.com";
 const OPENROUTER_API_BASE_URL =
   process.env.OPENROUTER_API_BASE_URL || "https://openrouter.ai/api";
+const REQUESTY_API_BASE_URL =
+  process.env.REQUESTY_API_BASE_URL || "https://router.requesty.ai";
 const OPENAI_API_BASE_URL =
   process.env.OPENAI_API_BASE_URL || "https://api.openai.com";
 const ANTHROPIC_API_BASE_URL =
@@ -92,6 +94,10 @@ export default async function Config(phase: string) {
         {
           source: "/api/ai/openrouter/:path*",
           destination: `${OPENROUTER_API_BASE_URL}/:path*`,
+        },
+        {
+          source: "/api/ai/requesty/:path*",
+          destination: `${REQUESTY_API_BASE_URL}/:path*`,
         },
         {
           source: "/api/ai/openai/:path*",

--- a/src/app/api/ai/requesty/[...slug]/route.ts
+++ b/src/app/api/ai/requesty/[...slug]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { REQUESTY_BASE_URL } from "@/constants/urls";
+
+export const runtime = "edge";
+export const preferredRegion = [
+  "cle1",
+  "iad1",
+  "pdx1",
+  "sfo1",
+  "sin1",
+  "syd1",
+  "hnd1",
+  "kix1",
+];
+
+const API_PROXY_BASE_URL =
+  process.env.REQUESTY_API_BASE_URL || REQUESTY_BASE_URL;
+
+async function handler(req: NextRequest) {
+  let body;
+  if (req.method.toUpperCase() !== "GET") {
+    body = await req.json();
+  }
+  const searchParams = req.nextUrl.searchParams;
+  const path = searchParams.getAll("slug");
+  searchParams.delete("slug");
+  const params = searchParams.toString();
+
+  try {
+    let url = `${API_PROXY_BASE_URL}/${decodeURIComponent(path.join("/"))}`;
+    if (params) url += `?${params}`;
+    const payload: RequestInit = {
+      method: req.method,
+      headers: {
+        "Content-Type": req.headers.get("Content-Type") || "application/json",
+        Authorization: req.headers.get("Authorization") || "",
+      },
+    };
+    if (body) payload.body = JSON.stringify(body);
+    const response = await fetch(url, payload);
+    return new NextResponse(response.body, response);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(error);
+      return NextResponse.json(
+        { code: 500, message: error.message },
+        { status: 500 }
+      );
+    }
+  }
+}
+
+export { handler as GET, handler as POST, handler as PUT, handler as DELETE };

--- a/src/app/api/utils.ts
+++ b/src/app/api/utils.ts
@@ -6,6 +6,8 @@ const GOOGLE_GENERATIVE_AI_API_BASE_URL =
   "https://generativelanguage.googleapis.com";
 const OPENROUTER_API_BASE_URL =
   process.env.OPENROUTER_API_BASE_URL || "https://openrouter.ai/api";
+const REQUESTY_API_BASE_URL =
+  process.env.REQUESTY_API_BASE_URL || "https://router.requesty.ai";
 const OPENAI_API_BASE_URL =
   process.env.OPENAI_API_BASE_URL || "https://api.openai.com";
 const ANTHROPIC_API_BASE_URL =
@@ -41,6 +43,7 @@ const SEARXNG_API_BASE_URL =
 const GOOGLE_GENERATIVE_AI_API_KEY =
   process.env.GOOGLE_GENERATIVE_AI_API_KEY || "";
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || "";
+const REQUESTY_API_KEY = process.env.REQUESTY_API_KEY || "";
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY || "";
 const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || "";
 const DEEPSEEK_API_KEY = process.env.DEEPSEEK_API_KEY || "";
@@ -77,6 +80,8 @@ export function getAIProviderBaseURL(provider: string) {
       return AZURE_API_BASE_URL;
     case "openrouter":
       return completePath(OPENROUTER_API_BASE_URL, "/api/v1");
+    case "requesty":
+      return completePath(REQUESTY_API_BASE_URL, "/v1");
     case "openaicompatible":
       return completePath(OPENAI_COMPATIBLE_API_BASE_URL, "/v1");
     case "pollinations":
@@ -110,6 +115,8 @@ export function getAIProviderApiKey(provider: string) {
       return AZURE_API_KEY;
     case "openrouter":
       return OPENROUTER_API_KEY;
+    case "requesty":
+      return REQUESTY_API_KEY;
     case "openaicompatible":
       return OPENAI_COMPATIBLE_API_KEY;
     case "google-vertex":

--- a/src/components/Setting.tsx
+++ b/src/components/Setting.tsx
@@ -55,6 +55,7 @@ import { useSettingStore } from "@/store/setting";
 import {
   GEMINI_BASE_URL,
   OPENROUTER_BASE_URL,
+  REQUESTY_BASE_URL,
   OPENAI_BASE_URL,
   ANTHROPIC_BASE_URL,
   DEEPSEEK_BASE_URL,
@@ -117,6 +118,10 @@ const formSchema = z.object({
   openRouterApiProxy: z.string().optional(),
   openRouterThinkingModel: z.string().optional(),
   openRouterNetworkingModel: z.string().optional(),
+  requestyApiKey: z.string().optional(),
+  requestyApiProxy: z.string().optional(),
+  requestyThinkingModel: z.string().optional(),
+  requestyNetworkingModel: z.string().optional(),
   openAIApiKey: z.string().optional(),
   openAIApiProxy: z.string().optional(),
   openAIThinkingModel: z.string().optional(),
@@ -252,6 +257,8 @@ function Setting({ open, onClose }: SettingProps) {
       return filterThinkingModelList(modelList);
     } else if (provider === "openrouter") {
       return filterOpenRouterModelList(modelList);
+    } else if (provider === "requesty") {
+      return filterOpenRouterModelList(modelList);
     } else if (provider === "deepseek") {
       return filterDeepSeekModelList(modelList);
     } else if (provider === "atlascloud") {
@@ -268,6 +275,8 @@ function Setting({ open, onClose }: SettingProps) {
     if (provider === "google") {
       return filterNetworkingModelList(modelList);
     } else if (provider === "openrouter") {
+      return filterOpenRouterModelList(modelList);
+    } else if (provider === "requesty") {
       return filterOpenRouterModelList(modelList);
     } else if (provider === "openai") {
       return filterOpenAIModelList(modelList);
@@ -543,6 +552,11 @@ function Setting({ open, onClose }: SettingProps) {
                                 OpenRouter
                               </SelectItem>
                             ) : null}
+                            {!isDisabledAIProvider("requesty") ? (
+                              <SelectItem value="requesty">
+                                Requesty
+                              </SelectItem>
+                            ) : null}
                             {!isDisabledAIProvider("ollama") ? (
                               <SelectItem value="ollama">Ollama</SelectItem>
                             ) : null}
@@ -785,6 +799,62 @@ function Setting({ open, onClose }: SettingProps) {
                                 updateSetting(
                                   "openRouterApiProxy",
                                   form.getValues("openRouterApiProxy"),
+                                )
+                              }
+                            />
+                          </FormControl>
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+                  <div
+                    className={cn("space-y-4", {
+                      hidden: provider !== "requesty",
+                    })}
+                  >
+                    <FormField
+                      control={form.control}
+                      name="requestyApiKey"
+                      render={({ field }) => (
+                        <FormItem className="from-item">
+                          <FormLabel className="from-label">
+                            {t("setting.apiKeyLabel")}
+                            <span className="ml-1 text-red-500 max-sm:hidden">
+                              *
+                            </span>
+                          </FormLabel>
+                          <FormControl className="form-field">
+                            <Password
+                              type="text"
+                              placeholder={t("setting.apiKeyPlaceholder")}
+                              {...field}
+                              onBlur={() =>
+                                updateSetting(
+                                  "requestyApiKey",
+                                  form.getValues("requestyApiKey"),
+                                )
+                              }
+                            />
+                          </FormControl>
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="requestyApiProxy"
+                      render={({ field }) => (
+                        <FormItem className="from-item">
+                          <FormLabel className="from-label">
+                            {t("setting.apiUrlLabel")}
+                          </FormLabel>
+                          <FormControl className="form-field">
+                            <Input
+                              placeholder={REQUESTY_BASE_URL}
+                              {...field}
+                              onBlur={() =>
+                                updateSetting(
+                                  "requestyApiProxy",
+                                  form.getValues("requestyApiProxy"),
                                 )
                               }
                             />
@@ -1627,6 +1697,180 @@ function Setting({ open, onClose }: SettingProps) {
                   <FormField
                     control={form.control}
                     name="openRouterNetworkingModel"
+                    render={({ field }) => (
+                      <FormItem className="from-item">
+                        <FormLabel className="from-label">
+                          <HelpTip tip={t("setting.networkingModelTip")}>
+                            {t("setting.networkingModel")}
+                            <span className="ml-1 text-red-500 max-sm:hidden">
+                              *
+                            </span>
+                          </HelpTip>
+                        </FormLabel>
+                        <FormControl>
+                          <div className="form-field w-full">
+                            <Select
+                              value={field.value}
+                              onValueChange={field.onChange}
+                            >
+                              <SelectTrigger
+                                className={cn({
+                                  hidden: modelList.length === 0,
+                                })}
+                              >
+                                <SelectValue
+                                  placeholder={t(
+                                    "setting.modelListLoadingPlaceholder",
+                                  )}
+                                />
+                              </SelectTrigger>
+                              <SelectContent className="max-sm:max-h-72">
+                                {networkingModelList[0].length > 0 ? (
+                                  <SelectGroup>
+                                    <SelectLabel>
+                                      {t("setting.recommendedModels")}
+                                    </SelectLabel>
+                                    {networkingModelList[0].map((name) => {
+                                      return !isDisabledAIModel(name) ? (
+                                        <SelectItem key={name} value={name}>
+                                          {convertModelName(name)}
+                                        </SelectItem>
+                                      ) : null;
+                                    })}
+                                  </SelectGroup>
+                                ) : null}
+                                <SelectGroup>
+                                  <SelectLabel>
+                                    {t("setting.basicModels")}
+                                  </SelectLabel>
+                                  {networkingModelList[1].map((name) => {
+                                    return !isDisabledAIModel(name) ? (
+                                      <SelectItem key={name} value={name}>
+                                        {convertModelName(name)}
+                                      </SelectItem>
+                                    ) : null;
+                                  })}
+                                </SelectGroup>
+                              </SelectContent>
+                            </Select>
+                            <Button
+                              className={cn("w-full", {
+                                hidden: modelList.length > 0,
+                              })}
+                              type="button"
+                              variant="outline"
+                              disabled={isRefreshing}
+                              onClick={() => fetchModelList()}
+                            >
+                              {isRefreshing ? (
+                                <>
+                                  <RefreshCw className="animate-spin" />{" "}
+                                  {t("setting.modelListLoading")}
+                                </>
+                              ) : (
+                                <>
+                                  <RefreshCw /> {t("setting.refresh")}
+                                </>
+                              )}
+                            </Button>
+                          </div>
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <div
+                  className={cn("space-y-4", {
+                    hidden: provider !== "requesty",
+                  })}
+                >
+                  <FormField
+                    control={form.control}
+                    name="requestyThinkingModel"
+                    render={({ field }) => (
+                      <FormItem className="from-item">
+                        <FormLabel className="from-label">
+                          <HelpTip tip={t("setting.thinkingModelTip")}>
+                            {t("setting.thinkingModel")}
+                            <span className="ml-1 text-red-500 max-sm:hidden">
+                              *
+                            </span>
+                          </HelpTip>
+                        </FormLabel>
+                        <FormControl>
+                          <div className="form-field w-full">
+                            <Select
+                              value={field.value}
+                              onValueChange={field.onChange}
+                            >
+                              <SelectTrigger
+                                className={cn({
+                                  hidden: modelList.length === 0,
+                                })}
+                              >
+                                <SelectValue
+                                  placeholder={t(
+                                    "setting.modelListLoadingPlaceholder",
+                                  )}
+                                />
+                              </SelectTrigger>
+                              <SelectContent className="max-sm:max-h-72">
+                                {thinkingModelList[0].length > 0 ? (
+                                  <SelectGroup>
+                                    <SelectLabel>
+                                      {t("setting.recommendedModels")}
+                                    </SelectLabel>
+                                    {thinkingModelList[0].map((name) => {
+                                      return !isDisabledAIModel(name) ? (
+                                        <SelectItem key={name} value={name}>
+                                          {convertModelName(name)}
+                                        </SelectItem>
+                                      ) : null;
+                                    })}
+                                  </SelectGroup>
+                                ) : null}
+                                <SelectGroup>
+                                  <SelectLabel>
+                                    {t("setting.basicModels")}
+                                  </SelectLabel>
+                                  {thinkingModelList[1].map((name) => {
+                                    return !isDisabledAIModel(name) ? (
+                                      <SelectItem key={name} value={name}>
+                                        {convertModelName(name)}
+                                      </SelectItem>
+                                    ) : null;
+                                  })}
+                                </SelectGroup>
+                              </SelectContent>
+                            </Select>
+                            <Button
+                              className={cn("w-full", {
+                                hidden: modelList.length > 0,
+                              })}
+                              type="button"
+                              variant="outline"
+                              disabled={isRefreshing}
+                              onClick={() => fetchModelList()}
+                            >
+                              {isRefreshing ? (
+                                <>
+                                  <RefreshCw className="animate-spin" />{" "}
+                                  {t("setting.modelListLoading")}
+                                </>
+                              ) : (
+                                <>
+                                  <RefreshCw /> {t("setting.refresh")}
+                                </>
+                              )}
+                            </Button>
+                          </div>
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="requestyNetworkingModel"
                     render={({ field }) => (
                       <FormItem className="from-item">
                         <FormLabel className="from-label">

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,6 +1,7 @@
 // Models API Base URL
 export const GEMINI_BASE_URL = "https://generativelanguage.googleapis.com";
 export const OPENROUTER_BASE_URL = "https://openrouter.ai";
+export const REQUESTY_BASE_URL = "https://router.requesty.ai";
 export const OPENAI_BASE_URL = "https://api.openai.com";
 export const ANTHROPIC_BASE_URL = "https://api.anthropic.com";
 export const DEEPSEEK_BASE_URL = "https://api.deepseek.com";

--- a/src/hooks/useAiProvider.ts
+++ b/src/hooks/useAiProvider.ts
@@ -6,6 +6,7 @@ import {
 import {
   GEMINI_BASE_URL,
   OPENROUTER_BASE_URL,
+  REQUESTY_BASE_URL,
   OPENAI_BASE_URL,
   ANTHROPIC_BASE_URL,
   DEEPSEEK_BASE_URL,
@@ -174,6 +175,19 @@ function useModelProvider() {
           options.baseURL = location.origin + "/api/ai/openrouter/api/v1";
         }
         break;
+      case "requesty":
+        const { requestyApiKey = "", requestyApiProxy } =
+          useSettingStore.getState();
+        if (mode === "local") {
+          options.baseURL = completePath(
+            requestyApiProxy || REQUESTY_BASE_URL,
+            "/v1"
+          );
+          options.apiKey = multiApiKeyPolling(requestyApiKey);
+        } else {
+          options.baseURL = location.origin + "/api/ai/requesty/v1";
+        }
+        break;
       case "openaicompatible":
         const { openAICompatibleApiKey = "", openAICompatibleApiProxy } =
           useSettingStore.getState();
@@ -290,6 +304,13 @@ function useModelProvider() {
           thinkingModel: openRouterThinkingModel,
           networkingModel: openRouterNetworkingModel,
         };
+      case "requesty":
+        const { requestyThinkingModel, requestyNetworkingModel } =
+          useSettingStore.getState();
+        return {
+          thinkingModel: requestyThinkingModel,
+          networkingModel: requestyNetworkingModel,
+        };
       case "openaicompatible":
         const {
           openAICompatibleThinkingModel,
@@ -353,6 +374,9 @@ function useModelProvider() {
       case "openrouter":
         const { openRouterApiKey } = useSettingStore.getState();
         return openRouterApiKey.length > 0;
+      case "requesty":
+        const { requestyApiKey } = useSettingStore.getState();
+        return requestyApiKey.length > 0;
       case "openaicompatible":
         const { openAICompatibleApiKey } = useSettingStore.getState();
         return openAICompatibleApiKey.length > 0;

--- a/src/hooks/useModelList.ts
+++ b/src/hooks/useModelList.ts
@@ -3,6 +3,7 @@ import { useSettingStore } from "@/store/setting";
 import {
   GEMINI_BASE_URL,
   OPENROUTER_BASE_URL,
+  REQUESTY_BASE_URL,
   OPENAI_BASE_URL,
   ANTHROPIC_BASE_URL,
   DEEPSEEK_BASE_URL,
@@ -158,6 +159,28 @@ function useModelList() {
           ? completePath(openRouterApiProxy || OPENROUTER_BASE_URL, "/api/v1") +
               "/models"
           : "/api/ai/openrouter/v1/models",
+        {
+          headers: {
+            authorization: `Bearer ${mode === "local" ? apiKey : accessKey}`,
+          },
+        }
+      );
+      const { data = [] } = await response.json();
+      const newModelList = (data as OpenRouterModel[]).map((item) => item.id);
+      setModelList(newModelList);
+      return newModelList;
+    } else if (provider === "requesty") {
+      const { requestyApiKey = "", requestyApiProxy } =
+        useSettingStore.getState();
+      if (mode === "local" && !requestyApiKey) {
+        return [];
+      }
+      const apiKey = multiApiKeyPolling(requestyApiKey);
+      const response = await fetch(
+        mode === "local"
+          ? completePath(requestyApiProxy || REQUESTY_BASE_URL, "/v1") +
+              "/models"
+          : "/api/ai/requesty/v1/models",
         {
           headers: {
             authorization: `Bearer ${mode === "local" ? apiKey : accessKey}`,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,7 @@ const accessPassword = process.env.ACCESS_PASSWORD || "";
 const GOOGLE_GENERATIVE_AI_API_KEY =
   process.env.GOOGLE_GENERATIVE_AI_API_KEY || "";
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || "";
+const REQUESTY_API_KEY = process.env.REQUESTY_API_KEY || "";
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY || "";
 const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || "";
 const DEEPSEEK_API_KEY = process.env.DEEPSEEK_API_KEY || "";
@@ -147,6 +148,46 @@ export async function middleware(request: NextRequest) {
       );
     } else {
       const apiKey = multiApiKeyPolling(OPENROUTER_API_KEY);
+      if (apiKey) {
+        const requestHeaders = new Headers();
+        requestHeaders.set(
+          "Content-Type",
+          request.headers.get("Content-Type") || "application/json",
+        );
+        requestHeaders.set("Authorization", `Bearer ${apiKey}`);
+        return NextResponse.next({
+          request: {
+            headers: requestHeaders,
+          },
+        });
+      } else {
+        return NextResponse.json(
+          {
+            error: ERRORS.NO_API_KEY,
+          },
+          { status: 500 },
+        );
+      }
+    }
+  }
+  if (request.nextUrl.pathname.startsWith("/api/ai/requesty")) {
+    const authorization = request.headers.get("authorization") || "";
+    const isDisabledModel = await hasDisabledAIModel();
+    if (
+      !verifySignature(
+        authorization.substring(7),
+        accessPassword,
+        Date.now(),
+      ) ||
+      disabledAIProviders.includes("requesty") ||
+      isDisabledModel
+    ) {
+      return NextResponse.json(
+        { error: ERRORS.NO_PERMISSIONS },
+        { status: 403 },
+      );
+    } else {
+      const apiKey = multiApiKeyPolling(REQUESTY_API_KEY);
       if (apiKey) {
         const requestHeaders = new Headers();
         requestHeaders.set(

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -17,6 +17,10 @@ export interface SettingStore {
   openRouterApiProxy: string;
   openRouterThinkingModel: string;
   openRouterNetworkingModel: string;
+  requestyApiKey: string;
+  requestyApiProxy: string;
+  requestyThinkingModel: string;
+  requestyNetworkingModel: string;
   openAIApiKey: string;
   openAIApiProxy: string;
   openAIThinkingModel: string;
@@ -120,6 +124,10 @@ export const defaultValues: SettingStore = {
   openRouterApiProxy: "",
   openRouterThinkingModel: "",
   openRouterNetworkingModel: "",
+  requestyApiKey: "",
+  requestyApiProxy: "",
+  requestyThinkingModel: "",
+  requestyNetworkingModel: "",
   openAIApiKey: "",
   openAIApiProxy: "",
   openAIThinkingModel: "gpt-5",

--- a/src/utils/deep-research/provider.ts
+++ b/src/utils/deep-research/provider.ts
@@ -114,6 +114,15 @@ export async function createAIProvider({
       apiKey,
     });
     return openrouter(model, settings);
+  } else if (provider === "requesty") {
+    // Requesty is an OpenAI-compatible LLM gateway. It uses the same
+    // baseURL + apiKey client shape as OpenRouter, so we reuse it here.
+    const { createOpenRouter } = await import("@openrouter/ai-sdk-provider");
+    const requesty = createOpenRouter({
+      baseURL,
+      apiKey,
+    });
+    return requesty(model, settings);
   } else if (provider === "openaicompatible") {
     const { createOpenAICompatible } = await import(
       "@ai-sdk/openai-compatible"


### PR DESCRIPTION
## What

Adds Requesty as a named, OpenAI-compatible LLM provider, mirroring the existing OpenRouter provider end-to-end (both local browser-direct mode and the server-side proxy mode).

Requesty (https://requesty.ai) is an OpenAI-compatible LLM gateway. It uses the same `provider/model` naming as OpenRouter (e.g. `openai/gpt-4o-mini`) and is reachable at `https://router.requesty.ai`.

## Changes

Mirrors each site where OpenRouter is wired, with no new dependencies (`@openrouter/ai-sdk-provider` is reused since Requesty is OpenAI-compatible) and no new translation strings (reuses existing generic setting keys):

- `src/constants/urls.ts`: `REQUESTY_BASE_URL`.
- `src/utils/deep-research/provider.ts`: `requesty` branch in the provider factory.
- `src/app/api/ai/requesty/[...slug]/route.ts`: server proxy route (new), mirroring the OpenRouter route.
- `src/store/setting.ts`: `requestyApiKey` / `requestyApiProxy` / `requestyThinkingModel` / `requestyNetworkingModel` fields + defaults.
- `src/hooks/useAiProvider.ts`: provider-creation, model resolution, and has-key sites.
- `src/hooks/useModelList.ts`: Requesty model-list fetch.
- `src/components/Setting.tsx`: provider picker entry, API key/proxy form, thinking/networking model pickers, and the zod schema fields.
- `src/app/api/utils.ts`, `src/middleware.ts`, `next.config.ts`: proxy-mode base URL/key resolution, auth + key injection, and rewrite rule.
- `env.tpl`: `REQUESTY_API_KEY` / `REQUESTY_API_BASE_URL`.

## Testing

- `tsc --noEmit`: clean (0 errors) after `pnpm install`.
- Live check against the real endpoint: `POST https://router.requesty.ai/v1/chat/completions` with `openai/gpt-4o-mini` → HTTP 200 with a valid completion.

---

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust wording/placement or close it if it's not a fit.

